### PR TITLE
Add HOCON parser to extract unique keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
 # HOCONconfReader
 Reader for hocon files which iterates trough the folders and returns back the hash map
+
+## HOCON Parser
+
+This project includes a HOCON parser that reads a Play Framework `.conf` file and returns all unique keys.
+
+### Usage
+
+To use the HOCON parser, follow these steps:
+
+1. Add the `com.typesafe.config` library to your project dependencies.
+2. Create a Scala object to call the parser.
+
+```scala
+import com.example.HOCONParser
+
+object Main extends App {
+  val filePath = "path/to/your/application.conf"
+  val uniqueKeys = HOCONParser.parseConfig(filePath)
+  println(s"Unique keys: ${uniqueKeys.mkString(", ")}")
+}
+```
+
+### Example
+
+Given the following `application.conf` file:
+
+```
+play {
+  application {
+    name = "example"
+    version = "1.0"
+  }
+  http {
+    port = 9000
+  }
+}
+```
+
+The parser will return the following unique keys:
+
+```
+play.application.name
+play.application.version
+play.http.port
+```
+
+### Running the Standalone App
+
+To run the standalone app via terminal, follow these steps:
+
+1. Ensure you have Scala installed on your system.
+2. Compile the Scala files using `scalac`.
+3. Run the `Main` object using `scala`.
+
+```sh
+scalac -cp "path/to/typesafe-config.jar" src/main/scala/com/example/HOCONParser.scala src/main/scala/com/example/Main.scala
+scala -cp "path/to/typesafe-config.jar:." com.example.Main
+```
+
+### Installation
+
+To install the necessary dependencies, follow these steps:
+
+1. Create a `build.sbt` file in the root directory of your project.
+2. Add the following content to the `build.sbt` file:
+
+```sbt
+name := "HOCONconfReader"
+
+version := "0.1"
+
+scalaVersion := "2.13.6"
+
+libraryDependencies += "com.typesafe" % "config" % "1.4.1"
+```
+
+3. Run `sbt update` to download and install the dependencies.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,16 @@
+# PowerShell script to install necessary dependencies for Windows systems
+
+# Install Scala
+Write-Host "Installing Scala..."
+choco install scala -y
+
+# Install sbt
+Write-Host "Installing sbt..."
+choco install sbt -y
+
+# Install com.typesafe.config library
+Write-Host "Installing com.typesafe.config library..."
+New-Item -ItemType Directory -Force -Path "lib"
+Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/com/typesafe/config/1.4.1/config-1.4.1.jar" -OutFile "lib\typesafe-config.jar"
+
+Write-Host "Installation completed."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Install Scala
+echo "Installing Scala..."
+sudo apt-get update
+sudo apt-get install -y scala
+
+# Install sbt
+echo "Installing sbt..."
+echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+sudo apt-get update
+sudo apt-get install -y sbt
+
+# Install com.typesafe.config library
+echo "Installing com.typesafe.config library..."
+mkdir -p lib
+cd lib
+curl -L -o typesafe-config.jar https://repo1.maven.org/maven2/com/typesafe/config/1.4.1/config-1.4.1.jar
+cd ..
+
+echo "Installation completed."

--- a/src/main/scala/HOCONParser.scala
+++ b/src/main/scala/HOCONParser.scala
@@ -1,0 +1,24 @@
+package com.example
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.collection.JavaConverters._
+
+object HOCONParser {
+  def parseConfig(filePath: String): Set[String] = {
+    val config: Config = ConfigFactory.parseFile(new java.io.File(filePath))
+    getAllKeys(config).toSet
+  }
+
+  private def getAllKeys(config: Config, parentKey: String = ""): Set[String] = {
+    config.entrySet().asScala.flatMap { entry =>
+      val key = if (parentKey.isEmpty) entry.getKey else s"$parentKey.${entry.getKey}"
+      entry.getValue.valueType() match {
+        case com.typesafe.config.ConfigValueType.OBJECT =>
+          getAllKeys(config.getConfig(entry.getKey), key)
+        case _ =>
+          Set(key)
+      }
+    }.toSet
+  }
+}

--- a/src/test/scala/HOCONParserTest.scala
+++ b/src/test/scala/HOCONParserTest.scala
@@ -1,0 +1,33 @@
+package com.example
+
+import org.scalatest.funsuite.AnyFunSuite
+import com.typesafe.config.ConfigFactory
+
+class HOCONParserTest extends AnyFunSuite {
+
+  test("HOCONParser should return all unique keys from a sample Play Framework .conf file") {
+    val sampleConfig =
+      """
+        |play {
+        |  application {
+        |    name = "example"
+        |    version = "1.0"
+        |  }
+        |  http {
+        |    port = 9000
+        |  }
+        |}
+        |""".stripMargin
+
+    val config = ConfigFactory.parseString(sampleConfig)
+    val uniqueKeys = HOCONParser.getAllKeys(config)
+
+    val expectedKeys = Set(
+      "play.application.name",
+      "play.application.version",
+      "play.http.port"
+    )
+
+    assert(uniqueKeys == expectedKeys)
+  }
+}


### PR DESCRIPTION
Add HOCON parser to read Play Framework `.conf` files and return unique keys.

* **HOCONParser.scala**
  - Implement a HOCON parser using `com.typesafe.config` library.
  - Extract all unique keys from the parsed configuration.
  - Return the unique keys as a `Set[String]`.

* **README.md**
  - Add instructions on how to use the HOCON parser.
  - Include an example of how to call the parser and retrieve unique keys.
  - Add instructions on how to run the standalone app via terminal.
  - Add instructions on how to install the necessary dependencies.

* **HOCONParserTest.scala**
  - Implement unit tests for the HOCON parser.
  - Test the parser with a sample Play Framework `.conf` file.
  - Verify that the parser correctly returns all unique keys.

* **install.sh**
  - Create a bash script to install necessary dependencies for Unix systems.
  - Include commands to install Scala and sbt.
  - Include commands to install the `com.typesafe.config` library.

* **install.ps1**
  - Create a PowerShell script to install necessary dependencies for Windows systems.
  - Include commands to install Scala and sbt.
  - Include commands to install the `com.typesafe.config` library.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=06e6b411-b2ca-48c7-b318-d076604fd6d0).