### PR TITLE
Replace bintray with alternative repository

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -21,8 +21,8 @@ jobs:
       run: sudo apt-get install -y scala
     - name: Install sbt
       run: |
-        echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | sudo apt-key add
         sudo apt-get update
         sudo apt-get install -y sbt
     - name: Run tests


### PR DESCRIPTION
Update the sbt installation step in the GitHub Actions workflow to use an alternative repository.

* Replace the bintray repository URL with the new sbt repository URL in `.github/workflows/scala.yml`
* Update the apt-key command to use the new keyserver URL in `.github/workflows/scala.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=3df48e04-d8f4-4d6a-9b5f-328c640b82af).