### PR TITLE
Fix tests in HOCONParserTest

### DIFF
--- a/src/test/scala/HOCONParserTest.scala
+++ b/src/test/scala/HOCONParserTest.scala
@@ -2,6 +2,7 @@ package com.example
 
 import org.scalatest.funsuite.AnyFunSuite
 import com.typesafe.config.ConfigFactory
+import java.io.File
 
 class HOCONParserTest extends AnyFunSuite {
 
@@ -32,8 +33,8 @@ class HOCONParserTest extends AnyFunSuite {
   }
 
   test("HOCONParser should correctly parse included configuration files") {
-    val config = ConfigFactory.parseResources("test.conf")
-    val uniqueKeys = HOCONParser.getAllKeys(config)
+    val config = ConfigFactory.parseFile(new File("src/test/resources/test.conf"))
+    val uniqueKeys = HOCONParser.parseConfig("src/test/resources/test.conf")
 
     val expectedKeys = Set(
       "included.settingA",


### PR DESCRIPTION
Fix test file issues in `HOCONParserTest.scala` to ensure tests run correctly.

* Import `java.io.File` to use `ConfigFactory.parseFile`.
* Replace `HOCONParser.getAllKeys` with `HOCONParser.parseConfig`.
* Use `ConfigFactory.parseFile(new File("src/test/resources/test.conf"))` instead of `ConfigFactory.parseResources("test.conf")`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=2f3908ee-7fad-4406-9025-a6bb094350c7).