### PR TITLE
Enhance test logging in HOCONParserTest

### DIFF
--- a/src/test/scala/HOCONParserTest.scala
+++ b/src/test/scala/HOCONParserTest.scala
@@ -7,8 +7,11 @@ import java.io.File
 class HOCONParserTest extends AnyFunSuite {
 
   test("HOCONParser should return all unique keys from a sample Play Framework .conf file") {
+    println("Starting test: HOCONParser should return all unique keys from a sample Play Framework .conf file")
     val config = ConfigFactory.parseFile(new File("src/test/resources/test.conf"))
     val uniqueKeys = HOCONParser.parseConfig("src/test/resources/test.conf")
+
+    println(s"Unique keys read: $uniqueKeys")
 
     val expectedKeys = Set(
       "included.settingA",
@@ -29,13 +32,18 @@ class HOCONParserTest extends AnyFunSuite {
     expectedKeys.foreach { key =>
       val actualValue = config.getString(key)
       val expectedValue = expectedValues(key)
+      println(s"Asserting key: $key, Actual value: $actualValue, Expected value: $expectedValue")
       assert(actualValue == expectedValue, s"Actual: $actualValue, expected: $expectedValue")
     }
+    println("Finished test: HOCONParser should return all unique keys from a sample Play Framework .conf file")
   }
 
   test("HOCONParser should correctly parse included configuration files") {
+    println("Starting test: HOCONParser should correctly parse included configuration files")
     val config = ConfigFactory.parseFile(new File("src/test/resources/test.conf"))
     val uniqueKeys = HOCONParser.parseConfig("src/test/resources/test.conf")
+
+    println(s"Unique keys read: $uniqueKeys")
 
     val expectedKeys = Set(
       "included.settingA",
@@ -56,13 +64,18 @@ class HOCONParserTest extends AnyFunSuite {
     expectedKeys.foreach { key =>
       val actualValue = config.getString(key)
       val expectedValue = expectedValues(key)
+      println(s"Asserting key: $key, Actual value: $actualValue, Expected value: $expectedValue")
       assert(actualValue == expectedValue, s"Actual: $actualValue, expected: $expectedValue")
     }
+    println("Finished test: HOCONParser should correctly parse included configuration files")
   }
 
   test("HOCONParser should correctly parse a sample Play Framework .conf file") {
+    println("Starting test: HOCONParser should correctly parse a sample Play Framework .conf file")
     val config = ConfigFactory.parseFile(new File("src/test/resources/test.conf"))
     val uniqueKeys = HOCONParser.parseConfig("src/test/resources/test.conf")
+
+    println(s"Unique keys read: $uniqueKeys")
 
     val expectedKeys = Set(
       "included.settingA",
@@ -83,7 +96,9 @@ class HOCONParserTest extends AnyFunSuite {
     expectedKeys.foreach { key =>
       val actualValue = config.getString(key)
       val expectedValue = expectedValues(key)
+      println(s"Asserting key: $key, Actual value: $actualValue, Expected value: $expectedValue")
       assert(actualValue == expectedValue, s"Actual: $actualValue, expected: $expectedValue")
     }
+    println("Finished test: HOCONParser should correctly parse a sample Play Framework .conf file")
   }
 }


### PR DESCRIPTION
Add verbose logging to the test file `src/test/scala/HOCONParserTest.scala` to provide more information about what has been read out.

* **Start and end of tests**
  - Add logging statements to indicate the start and end of each test.

* **Unique keys and values**
  - Add logging statements to log the unique keys read from the configuration file.
  - Add logging statements to log the values corresponding to the unique keys.

* **Assertions**
  - Add logging statements to log the expected and actual values during assertions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=cc698cad-7e06-4dfe-bc3c-bf9341dea556).