### PR TITLE
Add Python and Java versions of HOCON parser

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,0 +1,23 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Run tests
+      run: ./gradlew test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,25 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyhocon
+    - name: Run tests
+      run: python -m unittest discover -s src/test/python

--- a/src/main/java/HOCONParser.java
+++ b/src/main/java/HOCONParser.java
@@ -1,0 +1,32 @@
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueType;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HOCONParser {
+
+    public static Set<String> parseConfig(String filePath) {
+        Config config = ConfigFactory.parseFile(new File(filePath));
+        return getAllKeys(config);
+    }
+
+    private static Set<String> getAllKeys(Config config) {
+        return getAllKeys(config, "");
+    }
+
+    private static Set<String> getAllKeys(Config config, String parentKey) {
+        Set<String> keys = new HashSet<>();
+        for (String key : config.root().keySet()) {
+            String fullKey = parentKey.isEmpty() ? key : parentKey + "." + key;
+            if (config.getValue(key).valueType() == ConfigValueType.OBJECT) {
+                keys.addAll(getAllKeys(config.getConfig(key), fullKey));
+            } else {
+                keys.add(fullKey);
+            }
+        }
+        return keys;
+    }
+}

--- a/src/main/python/HOCONParser.py
+++ b/src/main/python/HOCONParser.py
@@ -1,0 +1,16 @@
+import pyhocon
+from typing import Set
+
+def parse_config(file_path: str) -> Set[str]:
+    config = pyhocon.ConfigFactory.parse_file(file_path)
+    return get_all_keys(config)
+
+def get_all_keys(config, parent_key: str = "") -> Set[str]:
+    keys = set()
+    for key, value in config.items():
+        full_key = f"{parent_key}.{key}" if parent_key else key
+        if isinstance(value, pyhocon.config_tree.ConfigTree):
+            keys.update(get_all_keys(value, full_key))
+        else:
+            keys.add(full_key)
+    return keys

--- a/src/test/java/HOCONParserTest.java
+++ b/src/test/java/HOCONParserTest.java
@@ -1,0 +1,36 @@
+import com.typesafe.config.ConfigFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HOCONParserTest {
+
+    @Test
+    public void testParseConfig() {
+        String filePath = "src/test/resources/test.conf";
+        Set<String> expectedKeys = Set.of(
+                "included.settingA",
+                "included.settingB",
+                "main.setting1",
+                "main.setting2"
+        );
+        Set<String> result = HOCONParser.parseConfig(filePath);
+        assertEquals(expectedKeys, result);
+    }
+
+    @Test
+    public void testParseIncludedConfig() {
+        String filePath = "src/test/resources/test.conf";
+        Set<String> expectedKeys = Set.of(
+                "included.settingA",
+                "included.settingB",
+                "main.setting1",
+                "main.setting2"
+        );
+        Set<String> result = HOCONParser.parseConfig(filePath);
+        assertEquals(expectedKeys, result);
+    }
+}

--- a/src/test/python/test_HOCONParser.py
+++ b/src/test/python/test_HOCONParser.py
@@ -1,0 +1,29 @@
+import unittest
+from HOCONParser import parse_config
+
+class TestHOCONParser(unittest.TestCase):
+
+    def test_parse_config(self):
+        file_path = "src/test/resources/test.conf"
+        expected_keys = {
+            "included.settingA",
+            "included.settingB",
+            "main.setting1",
+            "main.setting2"
+        }
+        result = parse_config(file_path)
+        self.assertEqual(result, expected_keys)
+
+    def test_parse_included_config(self):
+        file_path = "src/test/resources/test.conf"
+        expected_keys = {
+            "included.settingA",
+            "included.settingB",
+            "main.setting1",
+            "main.setting2"
+        }
+        result = parse_config(file_path)
+        self.assertEqual(result, expected_keys)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add Python and Java versions of the HOCON parser, including test files, without changing the current functionality of Scala.

* **Python Implementation:**
  - Add `src/main/python/HOCONParser.py` to implement the HOCON parser in Python using the `pyhocon` library.
  - Add `src/test/python/test_HOCONParser.py` to implement test cases for the Python HOCON parser using the `unittest` framework.

* **Java Implementation:**
  - Add `src/main/java/HOCONParser.java` to implement the HOCON parser in Java using the `com.typesafe.config` library.
  - Add `src/test/java/HOCONParserTest.java` to implement test cases for the Java HOCON parser using the `JUnit` framework.

* **CI Workflows:**
  - Add `.github/workflows/python.yml` to define a new GitHub Actions workflow for Python, setting up the workflow to run on push and pull request events, install Python dependencies, and run tests.
  - Add `.github/workflows/java.yml` to define a new GitHub Actions workflow for Java, setting up the workflow to run on push and pull request events, install Java dependencies, and run tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=4b2e6c49-3b40-44b8-be99-cb9620fb770c).