### PR TITLE
Fix Scala and Python tests

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Run tests
-      run: ./gradlew test
+      run: ./gradlew test --tests src/test/java/**

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -26,4 +26,4 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y sbt
     - name: Run tests
-      run: sbt test
+      run: sbt "testOnly * -- -l src/test/scala"


### PR DESCRIPTION
Update the GitHub Actions workflows to ensure that only the appropriate test files are used for each language.

* **Scala Workflow**
  - Modify `.github/workflows/scala.yml` to run only Scala test files located in `src/test/scala`.

* **Java Workflow**
  - Modify `.github/workflows/java.yml` to run only Java test files located in `src/test/java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=207fe820-85b5-4ba3-ae4c-8f2ea0792c63).