### PR TITLE
Fix python test by updating PYTHONPATH

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,4 +22,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyhocon
     - name: Run tests
-      run: python -m unittest discover -s src/test/python
+      run: PYTHONPATH=src/main/python python -m unittest discover -s src/test/python

--- a/src/test/python/test_HOCONParser.py
+++ b/src/test/python/test_HOCONParser.py
@@ -4,6 +4,7 @@ from HOCONParser import parse_config
 class TestHOCONParser(unittest.TestCase):
 
     def test_parse_config(self):
+        print("Starting test: test_parse_config")  # P584c
         file_path = "src/test/resources/test.conf"
         expected_keys = {
             "included.settingA",
@@ -11,10 +12,14 @@ class TestHOCONParser(unittest.TestCase):
             "main.setting1",
             "main.setting2"
         }
+        print(f"Expected keys: {expected_keys}")  # P9267
         result = parse_config(file_path)
+        print(f"Result: {result}")  # Pc795
         self.assertEqual(result, expected_keys)
+        print("Finished test: test_parse_config")  # Pd1a8
 
     def test_parse_included_config(self):
+        print("Starting test: test_parse_included_config")  # P584c
         file_path = "src/test/resources/test.conf"
         expected_keys = {
             "included.settingA",
@@ -22,8 +27,11 @@ class TestHOCONParser(unittest.TestCase):
             "main.setting1",
             "main.setting2"
         }
+        print(f"Expected keys: {expected_keys}")  # P9267
         result = parse_config(file_path)
+        print(f"Result: {result}")  # Pc795
         self.assertEqual(result, expected_keys)
+        print("Finished test: test_parse_included_config")  # Pd1a8
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add more verbose logging for Java test and update PYTHONPATH in GitHub Actions workflow.

* **src/test/python/test_HOCONParser.py**
  - Add print statements to log the start and end of each test.
  - Add print statements to log the expected keys and the result of the `parse_config` function.

* **.github/workflows/python.yml**
  - Update the `Run tests` step to include the `PYTHONPATH` environment variable.
  - Modify the `Run tests` command to `PYTHONPATH=src/main/python python -m unittest discover -s src/test/python`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=d5d3a87c-716f-42ac-90f4-fca7c9a46971).