### PR TITLE
Add file selector functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ scalac -cp "path/to/typesafe-config.jar" src/main/scala/com/example/HOCONParser.
 scala -cp "path/to/typesafe-config.jar:." com.example.Main
 ```
 
+### Running the File Selector
+
+To run the file selector via terminal, follow these steps:
+
+1. Ensure you have Scala installed on your system.
+2. Compile the Scala files using `scalac`.
+3. Run the `FileSelector` object using `scala`.
+
+```sh
+scalac -cp "path/to/typesafe-config.jar" src/main/scala/com/example/HOCONParser.scala src/main/scala/com/example/FileSelector.scala
+scala -cp "path/to/typesafe-config.jar:." com.example.FileSelector
+```
+
 ### Installation
 
 To install the necessary dependencies, follow these steps:
@@ -88,7 +101,7 @@ To install the necessary dependencies for Java, follow these steps:
 
 ```xml
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xsi="http://www.w3.org/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/POM/4.0.0">
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/scala/FileSelector.scala
+++ b/src/main/scala/FileSelector.scala
@@ -1,0 +1,15 @@
+package com.example
+
+import scala.io.StdIn.readLine
+
+object FileSelector {
+  def main(args: Array[String]): Unit = {
+    println("Please enter the path to the HOCON file you want to read:")
+    val filePath = readLine()
+    val uniqueKeys = HOCONParser.parseConfig(filePath)
+    uniqueKeys.foreach { key =>
+      val value = HOCONParser.getConfigValue(filePath, key)
+      println(s"$key: $value")
+    }
+  }
+}


### PR DESCRIPTION
Add a new file `FileSelector.scala` to prompt the user to select a file and read its contents.

* **FileSelector.scala**
  - Create a new Scala file `FileSelector.scala` in the `src/main/scala` directory.
  - Add a method to prompt the user to select a file.
  - Call the existing `HOCONParser` to read the selected file.
  - Print the unique keys and their values returned by the `HOCONParser`.

* **README.md**
  - Add instructions on how to use the new file selector functionality.
  - Update the example usage section to include the new file selector functionality.
  - Add a new section for running the file selector via terminal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=8c44d386-85b8-4c46-9caf-7840e7875a30).