### PR TITLE
Add React.js frontend and Node.js backend

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To install the necessary dependencies for Java, follow these steps:
 
 ```xml
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/XMLSchema-instance"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/POM/4.0.0">
 
     <modelVersion>4.0.0</modelVersion>
@@ -179,3 +179,14 @@ To run the installation scripts for Windows and Unix-based systems, follow these
 ```sh
 ./install.sh
 ```
+
+### Running the React.js Web Application
+
+To run the React.js web application, follow these steps:
+
+1. Navigate to the `web` directory.
+2. Install the necessary dependencies by running `npm install`.
+3. Start the development server by running `npm run dev`.
+4. Open your web browser and navigate to `http://localhost:3000` to access the application.
+
+The web application allows users to upload HOCON files, which are then parsed by the backend server. The parsed results are displayed in a user-friendly format, such as a table, list, or collapsible tree view.

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hoconconfreader",
+  "version": "1.0.0",
+  "description": "A web-based HOCON configuration file reader",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "client": "cd client && npm start",
+    "dev": "concurrently \"npm run start\" \"npm run client\""
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "multer": "^1.4.2",
+    "concurrently": "^6.2.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.7"
+  }
+}

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const multer = require('multer');
+const { exec } = require('child_process');
+const path = require('path');
+
+const app = express();
+const port = 5000;
+
+const upload = multer({ dest: 'uploads/' });
+
+app.post('/upload', upload.single('file'), (req, res) => {
+  const filePath = path.join(__dirname, req.file.path);
+
+  exec(`scala -cp "lib/*" com.example.FileSelector ${filePath}`, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Error executing Scala code: ${error.message}`);
+      return res.status(500).json({ error: 'Error parsing file' });
+    }
+
+    if (stderr) {
+      console.error(`Scala stderr: ${stderr}`);
+      return res.status(500).json({ error: 'Error parsing file' });
+    }
+
+    const parsedResults = parseScalaOutput(stdout);
+    res.json(parsedResults);
+  });
+});
+
+function parseScalaOutput(output) {
+  const lines = output.split('\n');
+  const results = {};
+
+  lines.forEach(line => {
+    const [key, value] = line.split(': ');
+    if (key && value) {
+      results[key] = value;
+    }
+  });
+
+  return results;
+}
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import FileUpload from './components/FileUpload';
+
+function App() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1>HOCON Configuration File Reader</h1>
+      </header>
+      <main>
+        <FileUpload />
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/web/src/components/FileUpload.js
+++ b/web/src/components/FileUpload.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import ParsedResults from './ParsedResults';
+
+const FileUpload = () => {
+  const [file, setFile] = useState(null);
+  const [parsedResults, setParsedResults] = useState(null);
+
+  const handleFileChange = (event) => {
+    setFile(event.target.files[0]);
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      alert('Please select a file first!');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const response = await axios.post('/upload', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      setParsedResults(response.data);
+    } catch (error) {
+      console.error('Error uploading file:', error);
+      alert('Error uploading file. Please try again.');
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={handleFileChange} />
+      <button onClick={handleUpload}>Upload</button>
+      {parsedResults && <ParsedResults results={parsedResults} />}
+    </div>
+  );
+};
+
+export default FileUpload;

--- a/web/src/components/ParsedResults.js
+++ b/web/src/components/ParsedResults.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const ParsedResults = ({ results }) => {
+  return (
+    <div>
+      <h2>Parsed Results</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(results).map(([key, value]) => (
+            <tr key={key}>
+              <td>{key}</td>
+              <td>{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ParsedResults;

--- a/web/src/components/TreeView.js
+++ b/web/src/components/TreeView.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+
+const TreeNode = ({ node, level }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleToggle = () => {
+    setExpanded(!expanded);
+  };
+
+  return (
+    <div style={{ marginLeft: level * 20 }}>
+      <div onClick={handleToggle} style={{ cursor: 'pointer' }}>
+        {node.children && (expanded ? '-' : '+')} {node.key}: {node.value}
+      </div>
+      {expanded && node.children && (
+        <div>
+          {node.children.map((childNode) => (
+            <TreeNode key={childNode.key} node={childNode} level={level + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TreeView = ({ results }) => {
+  const [treeData, setTreeData] = useState([]);
+
+  useEffect(() => {
+    const buildTree = (data) => {
+      const tree = [];
+      const map = {};
+
+      Object.entries(data).forEach(([key, value]) => {
+        const parts = key.split('.');
+        let currentLevel = tree;
+
+        parts.forEach((part, index) => {
+          if (!map[part]) {
+            const newNode = {
+              key: part,
+              value: index === parts.length - 1 ? value : '',
+              children: [],
+            };
+            currentLevel.push(newNode);
+            map[part] = newNode;
+          }
+
+          currentLevel = map[part].children;
+        });
+      });
+
+      return tree;
+    };
+
+    setTreeData(buildTree(results));
+  }, [results]);
+
+  return (
+    <div>
+      <h2>Parsed Results (Tree View)</h2>
+      {treeData.map((node) => (
+        <TreeNode key={node.key} node={node} level={0} />
+      ))}
+    </div>
+  );
+};
+
+export default TreeView;


### PR DESCRIPTION
Add a React.js web application to host the HOCON parser online.

* **Frontend Implementation**
  - Add `web/package.json` with necessary dependencies and scripts.
  - Create `web/src/App.js` as the main React component.
  - Create `web/src/components/FileUpload.js` for file upload functionality.
  - Create `web/src/components/ParsedResults.js` to display parsed results.
  - Create `web/src/components/TreeView.js` to display parsed results in a collapsible tree view.

* **Backend Implementation**
  - Add `web/server.js` to set up an Express.js server.
  - Use `multer` middleware for file uploads.
  - Use `child_process` module to execute Scala code and parse HOCON files.
  - Implement error handling and return parsed results to the frontend.

* **Documentation**
  - Update `README.md` with instructions for running the React.js web application.

* **CI/CD**
  - Add `.github/workflows/node.yml` to set up a CI workflow for testing the Node.js backend and React.js frontend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/HOCONconfReader?shareId=a3138a2b-37ca-4db5-b205-979d9aad750b).